### PR TITLE
create: pass right lxcpath to internal command

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -195,7 +195,7 @@ func startContainer(c *lxc.Container, spec *specs.Spec) error {
 		binary,
 		"internal",
 		c.Name(),
-		spec.Root.Path,
+		LXC_PATH,
 		filepath.Join(LXC_PATH, c.Name(), "config"),
 	)
 


### PR DESCRIPTION
the lxcpath is not the rootfs of the container, but rather the base used
for calculating various things, such as the command socket path or default
rootfs/config locations.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>