### PR TITLE
Fix container start sequence

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/apex/log"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -207,6 +208,11 @@ func startContainer(c *lxc.Container, spec *specs.Spec) error {
 
 	cmdErr := cmd.Start()
 
-	return cmdErr
+	if cmdErr == nil {
+		if !c.Wait(lxc.RUNNING, 30*time.Second) {
+			cmdErr = fmt.Errorf("Container failed to initialize")
+		}
+	}
 
+	return cmdErr
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/apex/log"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 
@@ -49,7 +50,12 @@ func doDelete(ctx *cli.Context) error {
 	}
 
 	if c.Running() {
-		return fmt.Errorf("container '%s' is running, cannot delete.", containerID)
+		if checkHackyPreStart(c) == "started" {
+			return fmt.Errorf("container '%s' is running, cannot delete.", containerID)
+		}
+		if err := c.Stop(); err != nil {
+			log.Warnf("Failed to stop pre-started container %s: %v", containerID, err)
+		}
 	}
 
 	// TODO: lxc-destroy deletes the rootfs.

--- a/cmd/kill.go
+++ b/cmd/kill.go
@@ -93,14 +93,13 @@ func doKill(ctx *cli.Context) error {
 
 	}
 
-	if !c.Running() {
-		return fmt.Errorf("container '%s' is not running", containerID)
-	}
+	if c.Running() && checkHackyPreStart(c) == "started" {
+		pid := c.InitPid()
 
-	pid := c.InitPid()
-
-	if err := unix.Kill(pid, signalMap[ctx.String("signal")]); err != nil {
-		return errors.Wrap(err, "failed to send signal")
+		if err := unix.Kill(pid, signalMap[ctx.String("signal")]); err != nil {
+			return errors.Wrap(err, "failed to send signal")
+		}
+		return nil
 	}
-	return nil
+	return fmt.Errorf("container '%s' is not running", containerID)
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -23,6 +23,27 @@ starts <containerID>
 `,
 }
 
+func checkHackyPreStart(c *lxc.Container) string {
+	hooks := c.ConfigItem("lxc.hook.pre-start")
+	for _, h := range hooks {
+		if h == "/bin/true" {
+			return "started"
+		}
+	}
+	return "prestart"
+}
+
+func setHackyPreStart(c *lxc.Container) {
+	err := c.SetConfigItem("lxc.hook.pre-start", "/bin/true")
+	if err != nil {
+		log.Warnf("Failed to set \"container started\" indicator: %v", err)
+	}
+	err = c.SaveConfigFile(filepath.Join(LXC_PATH, c.Name(), "config"))
+	if err != nil {
+		log.Warnf("Failed to save \"container started\" indicator: %v", err)
+	}
+}
+
 func doStart(ctx *cli.Context) error {
 	containerID := ctx.Args().Get(0)
 	if len(containerID) == 0 {
@@ -37,10 +58,14 @@ func doStart(ctx *cli.Context) error {
 	}
 	defer c.Release()
 	log.Infof("checking if running")
-	if c.Running() {
-		return fmt.Errorf("'%s' is already running", containerID)
+	if !c.Running() {
+		return fmt.Errorf("'%s' is not ready", containerID)
+	}
+	if checkHackyPreStart(c) == "started" {
+		return fmt.Errorf("'%s' already running", containerID)
 	}
 	log.Infof("not running, can start")
+	setHackyPreStart(c)
 	fifoPath := filepath.Join(LXC_PATH, containerID, "syncfifo")
 	log.Infof("opening fifo '%s'", fifoPath)
 	f, err := os.OpenFile(fifoPath, os.O_RDWR, 0)

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -55,7 +55,7 @@ func doState(ctx *cli.Context) error {
 	// https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc4/runtime.md#state
 	// it means "the container process has neither exited nor executed the user-specified program"
 	status := "stopped"
-	if c.Running() {
+	if c.Running() && checkHackyPreStart(c) == "started" {
 		status = "running"
 	}
 	pid := 0


### PR DESCRIPTION
Warning!  Major hack alert.

When we create a crio-lxc container, we start the lxc container to
wait for the syncfifo.  The crio-lxc container isn't really started
until the fifo is written to.

So we can't just use c.Running() to tell us that the crio-lxc container
is running.

Ideally we could add a 'criolxc.state' key in the container config.
Lxc would happily ignore that.  However, we cannot use the lxc api
to do that because it doesn't know about the keys.  And if we do it
ourselves, then we need to worry about locking.

So, add a pre-start hook of /bin/true to the config file when the
syncfifo is unlocked.  If anyone wants to set /bin/true as a real
pre-start hook, come talk to me.

Other ideas are definitely welcome!

Signed-off-by: Serge Hallyn <shallyn@cisco.com>