### PR TITLE
fix created status

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -47,7 +47,7 @@ function cleanup_crio {
 }
 
 function cleanup_tempdir {
-    rm -rf "$TEMP_DIR" || true
+    [ -f .keeptempdirs ] || rm -rf "$TEMP_DIR" || true
 }
 
 function crictl {

--- a/test/manual.bats
+++ b/test/manual.bats
@@ -16,7 +16,15 @@ function teardown() {
 
 @test "manual invocation" {
     crio-lxc --debug --log-level trace --log-file "$TEMP_DIR/log" create --bundle "$TEMP_DIR/dest" --pid-file "$TEMP_DIR/pid" alpine
+
+    status=$(crio-lxc --debug --log-level trace --log-file "$TEMP_DIR/log" state alpine | jq -r .status)
+    [ $status = "created" ]
+
     crio-lxc --debug --log-level trace --log-file "$TEMP_DIR/log" start alpine
+
+    status=$(crio-lxc --debug --log-level trace --log-file "$TEMP_DIR/log" state alpine | jq -r .status)
+    [ $status = "running" ]
+
     pid1ipcnsinode=$(stat -L -c%i /proc/1/ns/ipc)
     mypid=$(<"$TEMP_DIR/pid")
     mypidipcnsinode=$(stat -L -c%i "/proc/$mypid/ns/ipc")


### PR DESCRIPTION
if the container has been created with a 'create' call, but not started yet, even if we have a running underlying container, we need to report 'created' instead of 'running' or 'stopped'.

detect this case by always getting the PID if the container's running, and then using `/proc/$initpid/task/$initpid/children`, check for a single child running our fifo-waiter.

If that's the case, we are 'created'.

Adds this to the tests.